### PR TITLE
Enhance onboarding checks

### DIFF
--- a/sla_onboarding/README.md
+++ b/sla_onboarding/README.md
@@ -1,17 +1,17 @@
 # SLA Onboarding Scripts
 
-This folder contains scripts used to collect onboarding information for database servers. The `onboard_review.sh` script gathers server and database metadata for PostgreSQL, MariaDB and MySQL instances. The output format and destination can be chosen via the command line. Supported formats are:
+This folder contains scripts used to collect onboarding information for database servers.
 
-- **Text** (`.txt`)
-- **CSV** (`.csv`)
-- **JSON** (`.json`)
+`main_cli.sh` is a small wrapper that lets you run checks for PostgreSQL, MySQL, MariaDB or general OS information. Each database engine has its own helper script with functions that report version, data directory, memory settings and database sizes. For MySQL and MariaDB the running configuration and InnoDB status are also displayed.
 
-Run the script with optional flags:
+The original `onboard_review.sh` script is still provided for generating TXT/CSV/JSON reports but now you can also run more targeted checks:
 
 ```bash
-./onboard_review.sh            # default text output in the current directory
-./onboard_review.sh -f csv     # CSV output
-./onboard_review.sh -f all -o /tmp  # all formats in /tmp
+./main_cli.sh --postgres      # PostgreSQL checks
+./main_cli.sh --mysql         # MySQL checks
+./main_cli.sh --mariadb       # MariaDB checks
+./main_cli.sh --os            # OS summary
+./main_cli.sh --all           # run everything
 ```
 
-You may also provide custom paths for binaries and configuration files using `--psql`, `--mysql`, `--mariadb`, `--pgconf`, `--mysqlconf`, and `--mariadbconf`.
+For `onboard_review.sh`, you may specify output formats and custom binary paths using the existing flags (`--psql`, `--mysql`, `--mariadb`, ...).

--- a/sla_onboarding/main_cli.sh
+++ b/sla_onboarding/main_cli.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Main CLI for SLA onboarding checks
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+source "$SCRIPT_DIR/os_checks.sh"
+source "$SCRIPT_DIR/postgres_checks.sh"
+source "$SCRIPT_DIR/mysql_checks.sh"
+source "$SCRIPT_DIR/mariadb_checks.sh"
+
+usage() {
+  cat <<USAGE
+Usage: $0 [OPTIONS]
+  --postgres       Run PostgreSQL checks
+  --mysql          Run MySQL checks
+  --mariadb        Run MariaDB checks
+  --os             Run OS checks
+  --all            Run all checks
+  -h, --help       Show this help
+USAGE
+}
+
+run_postgres=false
+run_mysql=false
+run_mariadb=false
+run_os=false
+
+if [ $# -eq 0 ]; then
+  usage
+  exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --postgres) run_postgres=true ; shift ;;
+    --mysql) run_mysql=true ; shift ;;
+    --mariadb) run_mariadb=true ; shift ;;
+    --os) run_os=true ; shift ;;
+    --all) run_postgres=true; run_mysql=true; run_mariadb=true; run_os=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1"; usage; exit 1 ;;
+  esac
+done
+
+$run_os && os_summary
+if $run_postgres; then
+  pg_summary
+  pg_db_sizes
+fi
+if $run_mysql; then
+  mysql_summary
+fi
+if $run_mariadb; then
+  mariadb_summary
+fi
+
+exit 0

--- a/sla_onboarding/mariadb_checks.sh
+++ b/sla_onboarding/mariadb_checks.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# MariaDB specific checks
+
+MARIADB_CMD="$(command -v mariadb 2>/dev/null || command -v mysql 2>/dev/null || true)"
+
+mariadb_summary() {
+  echo "---- MariaDB Summary ----"
+  if [ -z "$MARIADB_CMD" ]; then
+    echo "mariadb command not found"; return
+  fi
+  local version=$($MARIADB_CMD -N -e 'SELECT VERSION();' 2>/dev/null)
+  local datadir=$($MARIADB_CMD -N -e 'SELECT @@datadir;' 2>/dev/null)
+  echo "Version: $version"
+  echo "Data Dir: $datadir"
+  mariadb_db_sizes
+  mariadb_show_config
+  mariadb_innodb_status
+}
+
+
+mariadb_memory() {
+  echo "---- MariaDB Memory ----"
+  [ -z "$MARIADB_CMD" ] && { echo "mariadb command not found"; return; }
+  $MARIADB_CMD -N -e "SHOW VARIABLES LIKE 'innodb_buffer_pool_size';" 2>/dev/null
+}
+
+mariadb_show_config() {
+  echo "---- MariaDB Configuration ----"
+  [ -z "$MARIADB_CMD" ] && { echo "mariadb command not found"; return; }
+  $MARIADB_CMD -e 'SHOW GLOBAL VARIABLES;' 2>/dev/null | head -n 20
+}
+
+mariadb_db_sizes() {
+  echo "---- MariaDB Database Sizes ----"
+  [ -z "$MARIADB_CMD" ] && { echo "mariadb command not found"; return; }
+  $MARIADB_CMD -N -e "SELECT table_schema, ROUND(SUM(data_length+index_length)/1024/1024,2) AS size_mb FROM information_schema.tables GROUP BY table_schema;" 2>/dev/null
+}
+
+mariadb_innodb_status() {
+  echo "---- MariaDB InnoDB Status ----"
+  [ -z "$MARIADB_CMD" ] && { echo "mariadb command not found"; return; }
+  $MARIADB_CMD -e 'SHOW ENGINE INNODB STATUS\G' 2>/dev/null | head -n 20
+}
+

--- a/sla_onboarding/mysql_checks.sh
+++ b/sla_onboarding/mysql_checks.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# MySQL specific checks
+
+MYSQL_CMD="$(command -v mysql 2>/dev/null || true)"
+
+mysql_summary() {
+  echo "---- MySQL Summary ----"
+  if [ -z "$MYSQL_CMD" ]; then
+    echo "mysql command not found"; return
+  fi
+  local version=$($MYSQL_CMD -N -e 'SELECT VERSION();' 2>/dev/null)
+  local datadir=$($MYSQL_CMD -N -e 'SELECT @@datadir;' 2>/dev/null)
+  echo "Version: $version"
+  echo "Data Dir: $datadir"
+  mysql_db_sizes
+  mysql_show_config
+  mysql_innodb_status
+}
+
+
+mysql_memory() {
+  echo "---- MySQL Memory ----"
+  [ -z "$MYSQL_CMD" ] && { echo "mysql command not found"; return; }
+  $MYSQL_CMD -N -e "SHOW VARIABLES LIKE 'innodb_buffer_pool_size';" 2>/dev/null
+}
+
+mysql_show_config() {
+  echo "---- MySQL Configuration ----"
+  [ -z "$MYSQL_CMD" ] && { echo "mysql command not found"; return; }
+  $MYSQL_CMD -e 'SHOW GLOBAL VARIABLES;' 2>/dev/null | head -n 20
+}
+
+mysql_db_sizes() {
+  echo "---- MySQL Database Sizes ----"
+  [ -z "$MYSQL_CMD" ] && { echo "mysql command not found"; return; }
+  $MYSQL_CMD -N -e "SELECT table_schema, ROUND(SUM(data_length+index_length)/1024/1024,2) AS size_mb FROM information_schema.tables GROUP BY table_schema;" 2>/dev/null
+}
+
+mysql_innodb_status() {
+  echo "---- MySQL InnoDB Status ----"
+  [ -z "$MYSQL_CMD" ] && { echo "mysql command not found"; return; }
+  $MYSQL_CMD -e 'SHOW ENGINE INNODB STATUS\G' 2>/dev/null | head -n 20
+}
+

--- a/sla_onboarding/os_checks.sh
+++ b/sla_onboarding/os_checks.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Basic OS related checks
+
+os_summary() {
+  echo "# System Summary ######################"
+  echo "        Date | $(date -u)"
+  echo "    Hostname | $(hostname)"
+  echo "      Uptime | $(uptime -p)"
+  echo "    Platform | $(uname -o)"
+  if command -v lsb_release >/dev/null 2>&1; then
+    echo "     Release | $(lsb_release -d | cut -f2)"
+  fi
+  echo "      Kernel | $(uname -r)"
+  echo "Architecture | CPU = $(uname -m), OS = 64-bit"
+  echo "   Threading | $(getconf GNU_LIBPTHREAD_VERSION)"
+  echo "     SELinux | $(getenforce 2>/dev/null || echo 'No SELinux detected')"
+  echo " Virtualized | $(systemd-detect-virt || echo 'No virtualization detected')"
+  echo "# Processor ##################################################"
+  lscpu | grep -E '^CPU\(s\):|Model name|Socket\(s\):|Thread\(s\) per core:|Core\(s\) per socket:'
+  echo "# Memory #####################################################"
+  free -h
+  echo "# Mounted Filesystems ########################################"
+  df -h | grep -vE '^tmpfs|cdrom'
+  echo "# Network Config #############################################"
+  echo " FIN Timeout | $(sysctl net.ipv4.tcp_fin_timeout | awk '{print $3}')"
+  echo "  Port Range | $(sysctl net.ipv4.ip_local_port_range | awk '{print $3}')"
+  echo "# Interface Statistics #######################################"
+  ip -s link show | awk '/^[0-9]+: / {print \"\"; print $2} {print $1, $2, $3}'
+  echo "# Top Processes ##############################################"
+  top -b -n 1 | head -n 15
+  if command -v aa-status >/dev/null 2>&1; then
+    echo "# AppArmor Status ############################################"
+    aa-status 2>/dev/null
+  else
+    echo "AppArmor status: not installed"
+  fi
+}
+

--- a/sla_onboarding/postgres_checks.sh
+++ b/sla_onboarding/postgres_checks.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# PostgreSQL specific checks derived from pg_dbaOverview.sh
+
+PG_BASE_DIRS=("/u02/pgdata" "/var/lib/postgresql")
+
+pg_find_clusters() {
+  local confs=()
+  for d in "${PG_BASE_DIRS[@]}"; do
+    [ -d "$d" ] && confs+=( $(find "$d" -type f -name postgresql.conf 2>/dev/null) )
+  done
+  printf '%s\n' "${confs[@]}"
+}
+
+pg_is_cluster_running() {
+  local data_dir="$1"
+  [ -f "$data_dir/postmaster.pid" ] && ps -p $(head -1 "$data_dir/postmaster.pid") >/dev/null 2>&1 && echo "online" || echo "down"
+}
+
+pg_get_port() {
+  local dir="$1"
+  if [ -f "$dir/postmaster.pid" ]; then
+    sed -n '4p' "$dir/postmaster.pid" | xargs
+  else
+    grep -E '^port' "$dir/postgresql.conf" 2>/dev/null | awk -F= '{print $2}' | awk '{print $1}' | head -n1
+  fi
+}
+
+pg_extract_version() {
+  local dir="$1"
+  if [[ "$dir" =~ /pgdata/([0-9]+)/ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    echo "unknown"
+  fi
+}
+
+pg_summary() {
+  echo "---- PostgreSQL Summary ----"
+  local confs
+  mapfile -t confs < <(pg_find_clusters)
+  for conf in "${confs[@]}"; do
+    local dir=$(dirname "$conf")
+    local name=$(basename "$dir")
+    local status=$(pg_is_cluster_running "$dir")
+    local port=$(pg_get_port "$dir")
+    local version=$(pg_extract_version "$dir")
+    echo "$name | version:$version | port:$port | status:$status"
+  done
+}
+
+pg_memory() {
+  echo "---- PostgreSQL Memory ----"
+  local confs
+  mapfile -t confs < <(pg_find_clusters)
+  for conf in "${confs[@]}"; do
+    local dir=$(dirname "$conf")
+    local port=$(pg_get_port "$dir")
+    local name=$(basename "$dir")
+    if [ "$(pg_is_cluster_running "$dir")" = "online" ]; then
+      echo "$name:"; psql -h localhost -p "$port" -d postgres -tAc "SHOW shared_buffers; SHOW work_mem;" 2>/dev/null
+    else
+      echo "$name is down"
+    fi
+  done
+}
+
+pg_disk() {
+  echo "---- PostgreSQL Config Files ----"
+  local confs
+  mapfile -t confs < <(pg_find_clusters)
+  for conf in "${confs[@]}"; do
+    local dir=$(dirname "$conf")
+    echo "$dir/postgresql.conf"
+    [ -f "$dir/pg_hba.conf" ] && echo "$dir/pg_hba.conf"
+  done
+}
+
+pg_replication() {
+  echo "---- PostgreSQL Replication ----"
+  local confs
+  mapfile -t confs < <(pg_find_clusters)
+  for conf in "${confs[@]}"; do
+    local dir=$(dirname "$conf")
+    local port=$(pg_get_port "$dir")
+    local name=$(basename "$dir")
+    if [ "$(pg_is_cluster_running "$dir")" = "online" ]; then
+      echo "$name replication:"; psql -h localhost -p "$port" -d postgres -c "SELECT * FROM pg_stat_replication;" 2>/dev/null
+    else
+      echo "$name is down"
+    fi
+  done
+}
+
+pg_logs() {
+  echo "---- PostgreSQL Logs ----"
+  local confs
+  mapfile -t confs < <(pg_find_clusters)
+  for conf in "${confs[@]}"; do
+    local dir=$(dirname "$conf")
+    local port=$(pg_get_port "$dir")
+    local name=$(basename "$dir")
+    if [ -f "$dir/postmaster.pid" ]; then
+      local log_dir=$(psql -h localhost -p "$port" -d postgres -Atc "SHOW log_directory" 2>/dev/null)
+      local log_file=$(psql -h localhost -p "$port" -d postgres -Atc "SHOW log_filename" 2>/dev/null)
+      log_dir=${log_dir:-$dir/pg_log}
+      [ "${log_dir:0:1}" != "/" ] && log_dir="$dir/$log_dir"
+      local full="$log_dir/$log_file"
+      echo "$name log ($full):"; [ -f "$full" ] && tail -n 10 "$full"
+    fi
+  done
+}
+
+pg_db_sizes() {
+  echo "---- PostgreSQL Database Sizes ----"
+  local confs
+  mapfile -t confs < <(pg_find_clusters)
+  for conf in "${confs[@]}"; do
+    local dir=$(dirname "$conf")
+    local port=$(pg_get_port "$dir")
+    local name=$(basename "$dir")
+    if [ "$(pg_is_cluster_running "$dir")" = "online" ]; then
+      echo "$name sizes:"; psql -h localhost -p "$port" -d postgres -Atc "SELECT datname, pg_size_pretty(pg_database_size(datname)) FROM pg_database;" 2>/dev/null
+    else
+      echo "$name is down"
+    fi
+  done
+}
+


### PR DESCRIPTION
## Summary
- expand OS summary with detailed system info and AppArmor status
- show database sizes and config details for MySQL and MariaDB
- display database sizes for PostgreSQL
- run new checks via main CLI
- update README with description of extra info

## Testing
- `bash -n sla_onboarding/main_cli.sh`
- `bash -n sla_onboarding/os_checks.sh`
- `bash -n sla_onboarding/mysql_checks.sh`
- `bash -n sla_onboarding/mariadb_checks.sh`
- `bash -n sla_onboarding/postgres_checks.sh`
- `bash -n sla_onboarding/onboard_review.sh`


------
https://chatgpt.com/codex/tasks/task_e_685d50e86ec0833380991e10bebe52a0